### PR TITLE
upgrade: upgrade to actions/checkout@v4 and actions/setup-go@v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.22
 


### PR DESCRIPTION
upgrade github actions workflow: actions/checkout from v2 to v4 and actions/setup-go from v2 to v5